### PR TITLE
Translate README to Spanish

### DIFF
--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,23 @@
+# Resumen de configuraci\u00f3n de Kricoin
+
+A continuaci\u00f3n se detallan los par\u00e1metros principales de la criptomoneda **Kricoin**.
+
+| Secci\u00f3n | Par\u00e1metro | Valor actual | Descripci\u00f3n |
+| --- | --- | --- | --- |
+| **Identidad** | coin name | Kricoin | Nombre personalizado de tu coin |
+| | currency code | KRC | Abreviatura est\u00e1ndar |
+| | address identifier byte | 0x2D | Direcciones comienzan con K |
+| | multisig address identifier byte | 0x30 | Para direcciones multifirma (K tambi\u00e9n) |
+| **Minado** | hash algorithm | scrypt | Algoritmo de miner\u00eda elegido |
+| | starting difficulty | 0.000050 | Muy baja, para facilitar inicio |
+| | desired seconds between blocks | 60 | Bloques cada 1 minuto |
+| | desired seconds to difficulty change | 216000 | Ajuste cada 2.5 d\u00edas |
+| **Recompensas** | initial block reward | 100 | Recompensa por bloque inicial |
+| | blocks until reward halves | 1680000 | Halving muy espaciado (~8 a\u00f1os) |
+| **Comisiones** | minimum sendable without dust fee | 0.00100000 (default) | A\u00fan requiere fee para evitar spam |
+| | minimum sendable at all | 0.00010000 (default) | L\u00edmite inferior para micropagos |
+| | largest tx in bytes without size fee | 10000 (default) | Tama\u00f1o sin fee por exceso de bytes |
+| **Bloques** | block size limit | 1000000 (default) | 1 MB como en Bitcoin (ajustable si crece la red) |
+| **Genesis** | genesis message | Personalizado por ti | Frase simb\u00f3lica fundacional (s\u00f3lo ASCII) |
+| **Governance** | governance | 000...000 (default vac\u00edo) | Sin sistema de gobernanza activo |
+

--- a/README_es.md
+++ b/README_es.md
@@ -4,20 +4,20 @@ A continuaci\u00f3n se detallan los par\u00e1metros principales de la criptomone
 
 | Secci\u00f3n | Par\u00e1metro | Valor actual | Descripci\u00f3n |
 | --- | --- | --- | --- |
-| **Identidad** | coin name | Kricoin | Nombre personalizado de tu coin |
-| | currency code | KRC | Abreviatura est\u00e1ndar |
-| | address identifier byte | 0x2D | Direcciones comienzan con K |
-| | multisig address identifier byte | 0x30 | Para direcciones multifirma (K tambi\u00e9n) |
-| **Minado** | hash algorithm | scrypt | Algoritmo de miner\u00eda elegido |
-| | starting difficulty | 0.000050 | Muy baja, para facilitar inicio |
-| | desired seconds between blocks | 60 | Bloques cada 1 minuto |
-| | desired seconds to difficulty change | 216000 | Ajuste cada 2.5 d\u00edas |
-| **Recompensas** | initial block reward | 100 | Recompensa por bloque inicial |
-| | blocks until reward halves | 1680000 | Halving muy espaciado (~8 a\u00f1os) |
-| **Comisiones** | minimum sendable without dust fee | 0.00100000 (default) | A\u00fan requiere fee para evitar spam |
-| | minimum sendable at all | 0.00010000 (default) | L\u00edmite inferior para micropagos |
-| | largest tx in bytes without size fee | 10000 (default) | Tama\u00f1o sin fee por exceso de bytes |
-| **Bloques** | block size limit | 1000000 (default) | 1 MB como en Bitcoin (ajustable si crece la red) |
-| **Genesis** | genesis message | Personalizado por ti | Frase simb\u00f3lica fundacional (s\u00f3lo ASCII) |
-| **Governance** | governance | 000...000 (default vac\u00edo) | Sin sistema de gobernanza activo |
+| **Identidad** | nombre de la moneda | Kricoin | Nombre personalizado de tu moneda |
+| | código de moneda | KRC | Abreviatura est\u00e1ndar |
+| | byte identificador de dirección | 0x2D | Direcciones comienzan con K |
+| | byte identificador para multisig | 0x30 | Para direcciones multifirma (K tambi\u00e9n) |
+| **Minado** | algoritmo de hash | scrypt | Algoritmo de miner\u00eda elegido |
+| | dificultad inicial | 0.000050 | Muy baja, para facilitar inicio |
+| | segundos deseados entre bloques | 60 | Bloques cada 1 minuto |
+| | segundos para cambio de dificultad | 216000 | Ajuste cada 2.5 d\u00edas |
+| **Recompensas** | recompensa inicial por bloque | 100 | Recompensa por bloque inicial |
+| | bloques hasta reducir recompensa a la mitad | 1680000 | Halving muy espaciado (~8 a\u00f1os) |
+| **Comisiones** | mínimo enviable sin comisión dust | 0.00100000 (predeterminado) | A\u00fan requiere fee para evitar spam |
+| | mínimo enviable total | 0.00010000 (predeterminado) | L\u00edmite inferior para micropagos |
+| | transacción más grande sin comisión por tamaño | 10000 (predeterminado) | Tama\u00f1o sin fee por exceso de bytes |
+| **Bloques** | límite de tamaño de bloque | 1000000 (predeterminado) | 1 MB como en Bitcoin (ajustable si crece la red) |
+| **Génesis** | mensaje de génesis | Personalizado por ti | Frase simb\u00f3lica fundacional (s\u00f3lo ASCII) |
+| **Governance** | gobernanza | 000...000 (predeterminado vacío) | Sin sistema de gobernanza activo |
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,44 +4,40 @@ Kricoin 0.8.x BETA
 Copyright (c) 2009-2013 Bitcoin Developers
 Copyright (c) 2011-2013 Litecoin Developers
 
-Distributed under the MIT/X11 software license, see the accompanying
-file COPYING or http://www.opensource.org/licenses/mit-license.php.
-This product includes software developed by the OpenSSL Project for use in the [OpenSSL Toolkit](http://www.openssl.org/). This product includes
-cryptographic software written by Eric Young ([eay@cryptsoft.com](mailto:eay@cryptsoft.com)), and UPnP software written by Thomas Bernard.
+Distribuido bajo la licencia de software MIT/X11; consulte el archivo COPYING o http://www.opensource.org/licenses/mit-license.php.
+Este producto incluye software desarrollado por el Proyecto OpenSSL para su uso en el OpenSSL Toolkit.
+Este producto incluye software criptográfico escrito por Eric Young (eay@cryptsoft.com), y software UPnP escrito por Thomas Bernard.
 
 
-Intro
+Introducción
 ---------------------
-Kricoin is a free open source peer-to-peer electronic cash system that is
-completely decentralized, without the need for a central server or trusted
-parties.  Users hold the crypto keys to their own money and transact directly
-with each other, with the help of a P2P network to check for double-spending.
+Kricoin es un sistema de dinero electrónico peer-to-peer de código abierto y gratuito que está completamente descentralizado, sin necesidad de un servidor central ni de partes de confianza.
+Los usuarios poseen las claves criptográficas de su propio dinero y realizan transacciones directamente entre sí, con la ayuda de una red P2P para comprobar el doble gasto.
 
 
-Setup
+Configuración
 ---------------------
-You need the Qt4 run-time libraries to run Kricoin-Qt. On Debian or Ubuntu:
-	`sudo apt-get install libqtgui4`
+Necesita las bibliotecas en tiempo de ejecución de Qt4 para ejecutar Kricoin-Qt. En Debian o Ubuntu:
+        `sudo apt-get install libqtgui4`
 
-Unpack the files into a directory and run:
+Descomprima los archivos en un directorio y ejecute:
 
 - bin/32/kricoin-qt (GUI, 32-bit)
-- bin/32/kricoind (headless, 32-bit)
+- bin/32/kricoind (sin interfaz, 32-bit)
 - bin/64/kricoin-qt (GUI, 64-bit)
-- bin/64/kricoind (headless, 64-bit)
+- bin/64/kricoind (sin interfaz, 64-bit)
 
-See the documentation at the [Kricoin Wiki](http://kricoin.info)
-for help and more information.
+Consulte la documentación en el [Wiki de Kricoin](http://kricoin.info) para obtener ayuda y más información.
 
 
-Other Pages
+Otras páginas
 ---------------------
-- [Unix Build Notes](build-unix.md)
-- [OSX Build Notes](build-osx.md)
-- [Windows Build Notes](build-msw.md)
-- [Coding Guidelines](coding.md)
-- [Release Process](release-process.md)
-- [Release Notes](release-notes.md)
-- [Multiwallet Qt Development](multiwallet-qt.md)
-- [Unit Tests](unit-tests.md)
-- [Translation Process](translation_process.md)
+- [Notas de compilación para Unix](build-unix.md)
+- [Notas de compilación para OSX](build-osx.md)
+- [Notas de compilación para Windows](build-msw.md)
+- [Guías de estilo de código](coding.md)
+- [Proceso de lanzamiento](release-process.md)
+- [Notas de lanzamiento](release-notes.md)
+- [Desarrollo de Multiwallet Qt](multiwallet-qt.md)
+- [Pruebas unitarias](unit-tests.md)
+- [Proceso de traducción](translation_process.md)


### PR DESCRIPTION
## Summary
- translate `doc/README.md` from English to Spanish

## Testing
- `make -f makefile.unix test_kricoin` *(fails: `BN_init` not declared in scope)*

------
https://chatgpt.com/codex/tasks/task_b_686899786df08324a189bf6074b0b4f9